### PR TITLE
[0 error pkg] add Kconfig file

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,30 @@
+# Kconfig file for package wm_libraries
+menuconfig PKG_USING_WM_LIBRARIES
+    bool "wm_libraries: a library package for WinnerMicro devices."
+    default n
+
+if PKG_USING_WM_LIBRARIES && ARCH_ARM_CORTEX_M3
+
+    config PKG_WM_LIBRARIES_PATH
+        string
+        default "/packages/peripherals/wm_libraries"
+
+    choice
+        prompt "Version"
+        default PKG_USING_WM_LIBRARIES_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_WM_LIBRARIES_V100
+            bool "v1.0.0"
+
+        config PKG_USING_WM_LIBRARIES_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_WM_LIBRARIES_VER
+       string
+       default "v1.0.0"    if PKG_USING_WM_LIBRARIES_V100
+       default "latest"    if PKG_USING_WM_LIBRARIES_LATEST_VERSION
+
+endif


### PR DESCRIPTION
wm_libraries目前似乎仅支持m3核，使用RTT软件包测试工具时无法通过，此处添加Kconfig依赖项，对非m3核bsp不做该软件包的使用